### PR TITLE
Added rule to overwrite Wordpress 4.9 Instagram providerPattern

### DIFF
--- a/src/Embed.php
+++ b/src/Embed.php
@@ -17,6 +17,7 @@ class Embed {
 		'#https?://www\.facebook\.com/watch/?\?v=\d+#i' => ['https://graph.facebook.com/v8.0/oembed_video', true],
 
 		'#https?://(www\.)?instagr(\.am|am\.com)/(p|tv)/.*#i' => ['https://graph.facebook.com/v8.0/instagram_oembed', true],
+		'#https?://(www\.)?instagr(\.am|am\.com)/p/.*#i' => ['https://graph.facebook.com/v8.0/instagram_oembed', true],
 	];
 
 	private $app_id;


### PR DESCRIPTION
I used this wonderful plugin on our WordPress website. 
Unfortunately, the plugin is for WordPress 5.4, we are still on version 4.9.
So I analyzed the code and I found that by simply adding a rule in the providerPatters array, the plugin works nicely also on 4.9. 

In this commit, I added the rule.
Hope it can help.

Paolo