### PR TITLE
Added instagram-reel support

### DIFF
--- a/src/Embed.php
+++ b/src/Embed.php
@@ -16,7 +16,7 @@ class Embed {
 		'#https?://www\.facebook\.com/video\.php.*#i' => ['https://graph.facebook.com/v8.0/oembed_video', true],
 		'#https?://www\.facebook\.com/watch/?\?v=\d+#i' => ['https://graph.facebook.com/v8.0/oembed_video', true],
 
-		'#https?://(www\.)?instagr(\.am|am\.com)/(p|tv)/.*#i' => ['https://graph.facebook.com/v8.0/instagram_oembed', true],
+		'#https?://(www\.)?instagr(\.am|am\.com)/(p|tv|reel)/.*#i' => ['https://graph.facebook.com/v8.0/instagram_oembed', true],
 		'#https?://(www\.)?instagr(\.am|am\.com)/p/.*#i' => ['https://graph.facebook.com/v8.0/instagram_oembed', true],
 	];
 


### PR DESCRIPTION
Instagram reel-embeds are available via the api also, so we have to adapt the regex only to support it

https://graph.facebook.com/v8.0/instagram_oembed?url=https%3A%2F%2Fwww.instagram.com%2Freel%2FCYd0tQfI6w7%2F&access_token=