### PR TITLE
Changes to support Watch, Reels, and API v15

### DIFF
--- a/oembed-plus.php
+++ b/oembed-plus.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:  oEmbed Plus
  * Plugin URI:   https://php.watch/articles/wordpress-facebook-instagram-oembed
- * Version:      1.6
+ * Version:      1.8.0
  * Description:  Adds support for embedding Facebook and Instagram posts in Block Editor and Classic Editor.
  * Licence:      GPLv2 or later
  * Author:       Ayesh Karunaratne
@@ -19,7 +19,7 @@ add_filter('oembed_providers', static function (array $providers): array {
 });
 
 add_filter('oembed_fetch_url', static function ($provider_url): string {
-	if (strpos($provider_url, 'https://graph.facebook.com/v8.0/') !== 0) {
+	if (strpos($provider_url, 'https://graph.facebook.com/v15.0/') !== 0) {
 		return $provider_url;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === oEmbed Plus ===
-Contributors: ayeshrajans
+Contributors: ayeshrajans, scorpionmit01   
 Tags: embed, facebook, instagram, oembed
 Requires at least: 4.9
-Tested up to: 5.6
-Stable tag: 1.6
+Tested up to: 6.1.1
+Stable tag: 1.8
 Requires PHP: 7.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/src/Embed.php
+++ b/src/Embed.php
@@ -4,20 +4,21 @@ namespace Ayesh\OembedPlus;
 
 class Embed {
 	private static $providerPatterns = [
-		'#https?://www\.facebook\.com/.*/posts/.*#i' => ['https://graph.facebook.com/v8.0/oembed_post', true],
-		'#https?://www\.facebook\.com/.*/activity/.*#i' => ['https://graph.facebook.com/v8.0/oembed_post', true],
-		'#https?://www\.facebook\.com/.*/photos/.*#i' => ['https://graph.facebook.com/v8.0/oembed_post', true],
-		'#https?://www\.facebook\.com/photo(s/|\.php).*#i' => ['https://graph.facebook.com/v8.0/oembed_post', true],
-		'#https?://www\.facebook\.com/permalink\.php.*#i' => ['https://graph.facebook.com/v8.0/oembed_post', true],
-		'#https?://www\.facebook\.com/media/.*#i' => ['https://graph.facebook.com/v8.0/oembed_post', true],
-		'#https?://www\.facebook\.com/questions/.*#i' => ['https://graph.facebook.com/v8.0/oembed_post', true],
-		'#https?://www\.facebook\.com/notes/.*#i' => ['https://graph.facebook.com/v8.0/oembed_post', true],
-		'#https?://www\.facebook\.com/.*/videos/.*#i' => ['https://graph.facebook.com/v8.0/oembed_video', true],
-		'#https?://www\.facebook\.com/video\.php.*#i' => ['https://graph.facebook.com/v8.0/oembed_video', true],
-		'#https?://www\.facebook\.com/watch/?\?v=\d+#i' => ['https://graph.facebook.com/v8.0/oembed_video', true],
+		'#https?://www\.facebook\.com/.*/posts/.*#i' => ['https://graph.facebook.com/v15.0/oembed_post', true],
+		'#https?://www\.facebook\.com/.*/activity/.*#i' => ['https://graph.facebook.com/v15.0/oembed_post', true],
+		'#https?://www\.facebook\.com/.*/photos/.*#i' => ['https://graph.facebook.com/v15.0/oembed_post', true],
+		'#https?://www\.facebook\.com/photo(s/|\/|\.php).*#i' => ['https://graph.facebook.com/v15.0/oembed_post', true],
+		'#https?://www\.facebook\.com/permalink\.php.*#i' => ['https://graph.facebook.com/v15.0/oembed_post', true],
+		'#https?://www\.facebook\.com/media/.*#i' => ['https://graph.facebook.com/v15.0/oembed_post', true],
+		'#https?://www\.facebook\.com/questions/.*#i' => ['https://graph.facebook.com/v15.0/oembed_post', true],
+		'#https?://www\.facebook\.com/notes/.*#i' => ['https://graph.facebook.com/v15.0/oembed_post', true],
+		'#https?://www\.facebook\.com/.*/videos/.*#i' => ['https://graph.facebook.com/v15.0/oembed_video', true],
+		'#https?://www\.facebook\.com/video\.php.*#i' => ['https://graph.facebook.com/v15.0/oembed_video', true],
+		'#https?://www\.facebook\.com/watch/?\?v=\d+#i' => ['https://graph.facebook.com/v15.0/oembed_video', true],
+		'#https?://(www\.)?fb\.watch/*#i'=> ['https://graph.facebook.com/v15.0/oembed_video', true],
 
-		'#https?://(www\.)?instagr(\.am|am\.com)/(p|tv)/.*#i' => ['https://graph.facebook.com/v8.0/instagram_oembed', true],
-		'#https?://(www\.)?instagr(\.am|am\.com)/p/.*#i' => ['https://graph.facebook.com/v8.0/instagram_oembed', true],
+		'#https?://(www\.)?instagr(\.am|am\.com)/(p|tv|reel)/.*#i' => ['https://graph.facebook.com/v15.0/instagram_oembed', true],
+		'#https?://(www\.)?instagr(\.am|am\.com)/p/.*#i' => ['https://graph.facebook.com/v15.0/instagram_oembed', true],
 	];
 
 	private $app_id;


### PR DESCRIPTION
I borrowed the Reels/Watch code from the other fork, added support for some additional Facebook URLs, and changed all the API versions from 8 to 15.

Please merge and upload to the Wordpress SVN so the Plugin there will work.